### PR TITLE
にじボイスのAPIからBase64の音声データを返すAPIが出たのでそれを利用するように変更

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,10 +17,6 @@ MacOSを利用する前提の手順になります。
 ```bash
 export GEMINI_API_KEY="https://aistudio.google.com/ で発行したAPIキー"
 export NIJIVOICE_API_KEY="https://platform.nijivoice.com/ で発行したAPIキー"
-export R2_ENDPOINT_URL="Cloudflareで作成したR2バケットのエンドポイントURLを指定（S3 APIの値）"
-export R2_ACCESS_KEY_ID="Cloudflareで作成したアクセスキーID"
-export R2_SECRET_ACCESS_KEY="Cloudflareで作成したアクセスシークレットキー"
-export R2_BUCKET_NAME="Cloudflareで作成したR2バケット名"
 ```
 
 ### uvのインストール

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -8,10 +8,6 @@ services:
     environment:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       NIJIVOICE_API_KEY: ${NIJIVOICE_API_KEY}
-      R2_ENDPOINT_URL: ${R2_ENDPOINT_URL}
-      R2_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID}
-      R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY}
-      R2_BUCKET_NAME: ${R2_BUCKET_NAME}
     volumes:
       - ./Makefile:/Makefile
       - ./pyproject.toml:/pyproject.toml

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,7 +5,6 @@ description = "AIとのリアルタイムなやり取りを行う為の実験用
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "boto3>=1.35.91",
     "fastapi>=0.115.6",
     "google-genai>=0.4.0",
     "types-requests>=2.32.0.20241016",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -28,7 +28,6 @@ name = "backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "boto3" },
     { name = "fastapi" },
     { name = "google-genai" },
     { name = "types-requests" },
@@ -47,7 +46,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.35.91" },
     { name = "fastapi", specifier = ">=0.115.6" },
     { name = "google-genai", specifier = ">=0.4.0" },
     { name = "types-requests", specifier = ">=2.32.0.20241016" },
@@ -62,34 +60,6 @@ dev = [
     { name = "pytest-env", specifier = ">=1.1.5" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.8.3" },
-]
-
-[[package]]
-name = "boto3"
-version = "1.35.91"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/90/a8a264091f80e1860371f2fc4e12b3e28c2ca33a6054a156fb4096732453/boto3-1.35.91.tar.gz", hash = "sha256:ba391982f6cada136c5bba99e85d7fe1bc4e157c53a22a78e4aca35d1b39152e", size = 111013 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/c9/7a111291cdb6e7273d5ff9989f2ef3131afb61ce41f5522e03c98390dff6/boto3-1.35.91-py3-none-any.whl", hash = "sha256:eecef248f8743ab30036cd9c916808a0892fc9036e1a35434d8222060c08bbd2", size = 139178 },
-]
-
-[[package]]
-name = "botocore"
-version = "1.35.91"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/d8/81df77f016087f7f959ce8b0778ff781b9491b8fc1ba45f7abf8179a8711/botocore-1.35.91.tar.gz", hash = "sha256:7b0b9c5954701fff4d2c516918f45641b04ff4ca92bbd9f5b37c0b80f8c14220", size = 13497671 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/c9/9105c812d1a9f35a1292f28dc344bf78bd29072bb547194e89b078a006c6/botocore-1.35.91-py3-none-any.whl", hash = "sha256:93de9d0f52f7e36a2c190d55520d3b2654f32c5a628fdd484bffa00bc7865e1d", size = 13300397 },
 ]
 
 [[package]]
@@ -233,15 +203,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
-]
-
-[[package]]
-name = "jmespath"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256 },
 ]
 
 [[package]]
@@ -429,18 +390,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
-]
-
-[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -490,27 +439,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/e9/5b81dc9afc8a80884405b230b9429efeef76d04caead904bd213f453b973/ruff-0.8.3-py3-none-win32.whl", hash = "sha256:19048f2f878f3ee4583fc6cb23fb636e48c2635e30fb2022b3a1cd293402f964", size = 8807651 },
     { url = "https://files.pythonhosted.org/packages/ea/67/7291461066007617b59a707887b90e319b6a043c79b4d19979f86b7a20e7/ruff-0.8.3-py3-none-win_amd64.whl", hash = "sha256:f7df94f57d7418fa7c3ffb650757e0c2b96cf2501a0b192c18e4fb5571dfada9", size = 9625289 },
     { url = "https://files.pythonhosted.org/packages/03/8f/e4fa95288b81233356d9a9dcaed057e5b0adc6399aa8fd0f6d784041c9c3/ruff-0.8.3-py3-none-win_arm64.whl", hash = "sha256:fe2756edf68ea79707c8d68b78ca9a58ed9af22e430430491ee03e718b5e4936", size = 9078754 },
-]
-
-[[package]]
-name = "s3transfer"
-version = "0.10.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/0a/1cdbabf9edd0ea7747efdf6c9ab4e7061b085aa7f9bfc36bb1601563b069/s3transfer-0.10.4.tar.gz", hash = "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7", size = 145287 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl", hash = "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e", size = 83175 },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]

--- a/frontend/src/app/_components/InputPromptForm.tsx
+++ b/frontend/src/app/_components/InputPromptForm.tsx
@@ -48,10 +48,9 @@ class Response {
 type Message = {
   role: 'user' | 'assistant';
   message: string;
-  audioUrl?: string;
 };
 
-const log = logger.child({ module: 'src/app/_components/InputPromptForm.tsx' });
+const log = logger.child({ module: 'InputPromptForm' });
 
 export function InputPromptForm() {
   const [prompt, setPrompt] = useState<string>('');
@@ -141,8 +140,13 @@ export function InputPromptForm() {
         return;
       }
 
-      const response = await fetch(audioUrl.current);
-      const arrayBuffer = await response.arrayBuffer();
+      // Base64データをデコードしてArrayBufferに変換
+      const binaryString = atob(audioUrl.current);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      const arrayBuffer = bytes.buffer;
 
       const audioBuffer = await playAudioContextRef.current.decodeAudioData(arrayBuffer);
 
@@ -203,7 +207,6 @@ export function InputPromptForm() {
           setMessages(prev => [...prev, {
             role: 'assistant',
             message: lastAssistantMessage,
-            audioUrl: audioUrl.current || undefined,
           }]);
           newResponseMessage = '';
           setStreamingMessage('');
@@ -436,7 +439,6 @@ export function InputPromptForm() {
               avatar="/omochi.png"
               message={message.message}
               showFeedback
-              audioUrl={message.audioUrl}
             />
           );
         })}

--- a/frontend/src/app/_components/MessageCard.tsx
+++ b/frontend/src/app/_components/MessageCard.tsx
@@ -3,7 +3,7 @@
 import { Icon } from '@iconify/react';
 import { Avatar, Badge, Button, cn, Link, Tooltip } from '@nextui-org/react';
 import { useClipboard } from '@nextui-org/use-clipboard';
-import { type HTMLAttributes, type ReactNode, type RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import { type HTMLAttributes, type ReactNode, type RefObject, useCallback, useRef, useState } from 'react';
 
 type Props = HTMLAttributes<HTMLDivElement> & {
   avatar?: string;
@@ -13,20 +13,17 @@ type Props = HTMLAttributes<HTMLDivElement> & {
   status?: 'success' | 'failed';
   attempts?: number;
   messageClassName?: string;
-  audioUrl?: string;
   onAttemptChange?: (attempt: number) => void;
   onMessageCopy?: (content: string | string[]) => void;
   onFeedback?: (feedback: 'like' | 'dislike') => void;
   onAttemptFeedback?: (feedback: 'like' | 'dislike' | 'same') => void;
 };
 
-export function MessageCard({ ref, avatar, message, showFeedback, attempts = 1, currentAttempt = 1, status, onMessageCopy, onAttemptChange, onFeedback, onAttemptFeedback, className, messageClassName, audioUrl, ...props }: Props & { ref?: RefObject<HTMLDivElement> }) {
+export function MessageCard({ ref, avatar, message, showFeedback, attempts = 1, currentAttempt = 1, status, onMessageCopy, onAttemptChange, onFeedback, onAttemptFeedback, className, messageClassName, ...props }: Props & { ref?: RefObject<HTMLDivElement> }) {
   const [feedback, setFeedback] = useState<'like' | 'dislike'>();
   const [attemptFeedback, setAttemptFeedback] = useState<'like' | 'dislike' | 'same'>();
-  const [isPlaying, setIsPlaying] = useState(false);
 
   const messageRef = useRef<HTMLDivElement>(null);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const { copied, copy } = useClipboard();
 
@@ -86,55 +83,6 @@ export function MessageCard({ ref, avatar, message, showFeedback, attempts = 1, 
     [onAttemptFeedback],
   );
 
-  const handlePlayAudio = async () => {
-    if (!audioUrl)
-      return;
-
-    if (audioRef.current) {
-      if (isPlaying) {
-        audioRef.current.pause();
-        setIsPlaying(false);
-        return;
-      }
-    }
-
-    try {
-      const audio = new Audio(audioUrl);
-      audioRef.current = audio;
-
-      // iOS対応の設定を追加
-      audio.playsInline = true;
-      audio.webkitPlaysInline = true;
-
-      audio.addEventListener('ended', () => {
-        setIsPlaying(false);
-        audioRef.current = null;
-      });
-
-      audio.addEventListener('error', () => {
-        setIsPlaying(false);
-        audioRef.current = null;
-      });
-
-      await audio.play();
-      setIsPlaying(true);
-    }
-    catch (error) {
-      console.error('音声再生エラー:', error);
-      setIsPlaying(false);
-    }
-  };
-
-  // コンポーネントのアンマウント時にクリーンアップ
-  useEffect(() => {
-    return () => {
-      if (audioRef.current) {
-        audioRef.current.pause();
-        audioRef.current = null;
-      }
-    };
-  }, []);
-
   return (
     <div {...props} ref={ref} className={cn('flex gap-3', className)}>
       <div className="relative flex-none">
@@ -162,20 +110,6 @@ export function MessageCard({ ref, avatar, message, showFeedback, attempts = 1, 
           </div>
           {showFeedback && !hasFailed && (
             <div className="absolute right-2 top-2 flex rounded-full bg-content2 shadow-small">
-              {audioUrl && (
-                <Button
-                  isIconOnly
-                  radius="full"
-                  size="sm"
-                  variant="light"
-                  onPress={handlePlayAudio}
-                >
-                  <Icon
-                    className="text-lg text-default-600"
-                    icon={isPlaying ? 'solar:pause-circle-linear' : 'solar:play-circle-linear'}
-                  />
-                </Button>
-              )}
               <Button isIconOnly radius="full" size="sm" variant="light" onPress={handleCopy}>
                 {copied
                   ? (


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/realtime-api-web-console/issues/29

# この PR で対応する範囲 / この PR で対応しない範囲

タイトルの通り、にじボイスのAPIのBase64版を利用するように変更する。

# 変更点概要

- バックエンドからWebSocketで `audio` を返しているがこの値はBase64された値 `generatedVoice.base64Audio` に変更
- これに伴い `R2` に音声データを保存する処理は削除する
- フロント側 `playAudio` 関数をBase64データが直接渡されてくる前提の処理に変更
- `MessageCard` に音声URLを受け取って再生出来る処理は削除

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし