### PR TITLE
WebSocketでデータをやり取りする時のキー名をcamelケースに統一

### DIFF
--- a/backend/src/presentation/controller/video_chat_controller.py
+++ b/backend/src/presentation/controller/video_chat_controller.py
@@ -184,21 +184,21 @@ class VideoChatController:
                                 message = await self.websocket.receive_text()
                                 data = json.loads(message)
 
-                                if "input_text" in data:
+                                if "inputText" in data:
                                     await session.send(
-                                        input=data["input_text"], end_of_turn=True
+                                        input=data["inputText"], end_of_turn=True
                                     )
 
-                                if "realtime_input" in data:
-                                    for chunk in data["realtime_input"]["media_chunks"]:
-                                        if chunk["mime_type"] == "audio/pcm":
+                                if "realtimeInput" in data:
+                                    for chunk in data["realtimeInput"]["mediaChunks"]:
+                                        if chunk["mimeType"] == "audio/pcm":
                                             await session.send(
                                                 input={
                                                     "mime_type": "audio/pcm",
                                                     "data": chunk["data"],
                                                 }
                                             )
-                                        elif chunk["mime_type"] == "image/jpeg":
+                                        elif chunk["mimeType"] == "image/jpeg":
                                             await session.send(
                                                 input={
                                                     "mime_type": "image/jpeg",

--- a/frontend/src/app/_components/InputPromptForm.tsx
+++ b/frontend/src/app/_components/InputPromptForm.tsx
@@ -296,10 +296,10 @@ export function InputPromptForm() {
 
           if (webSocketRef.current) {
             const payload = {
-              realtime_input: {
-                media_chunks: [
+              realtimeInput: {
+                mediaChunks: [
                   {
-                    mime_type: 'audio/pcm',
+                    mimeType: 'audio/pcm',
                     data: base64,
                   },
                 ],
@@ -362,10 +362,10 @@ export function InputPromptForm() {
       setPrompt('');
       if (webSocketRef.current) {
         const payload = {
-          input_text: textareaRef.current?.value,
+          inputText: textareaRef.current?.value,
         };
         webSocketRef.current.send(JSON.stringify(payload));
-        setMessages(prev => [...prev, { role: 'user', message: payload.input_text }]);
+        setMessages(prev => [...prev, { role: 'user', message: payload.inputText }]);
       }
     }
   };


### PR DESCRIPTION
# issueURL

#18 

# この PR で対応する範囲 / この PR で対応しない範囲

WebSocketでデータをやり取りする時のキー名をcamelケースに統一します。

# 変更点概要

WebSocketでデータをやり取りする時のキー名をcamelケースに統一しました。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし