### PR TITLE
ReceivedDataChannelMessageの型定義を追加

### DIFF
--- a/frontend/src/lib/openai.ts
+++ b/frontend/src/lib/openai.ts
@@ -1,0 +1,69 @@
+// WebRTCデータチャネルで受信するメッセージの型定義
+type SessionCreatedMessage = {
+  type: 'session.created';
+};
+
+type SessionUpdatedMessage = {
+  type: 'session.updated';
+};
+
+type ConversationItemCreatedMessage = {
+  type: 'conversation.item.created';
+  item: unknown;
+  previous_item_id: string;
+};
+
+type ResponseCreatedMessage = {
+  type: 'response.created';
+};
+
+type RateLimitsUpdatedMessage = {
+  type: 'rate_limits.updated';
+  rate_limits: {
+    requests_remaining: number;
+    tokens_remaining: number;
+  };
+};
+
+type ResponseOutputItemAddedMessage = {
+  type: 'response.output_item.added';
+};
+
+type ResponseContentPartAddedMessage = {
+  type: 'response.content_part.added';
+};
+
+type ResponseTextDeltaMessage = {
+  type: 'response.text.delta';
+  delta: string;
+};
+
+type ResponseTextDoneMessage = {
+  type: 'response.text.done';
+};
+
+type ResponseOutputItemDoneMessage = {
+  type: 'response.output_item.done';
+};
+
+type ResponseContentPartDoneMessage = {
+  type: 'response.content_part.done';
+};
+
+type ResponseDoneMessage = {
+  type: 'response.done';
+};
+
+export type ReceivedDataChannelMessage =
+  | SessionCreatedMessage
+  | SessionUpdatedMessage
+  | ConversationItemCreatedMessage
+  | ResponseCreatedMessage
+  | RateLimitsUpdatedMessage
+  | ResponseOutputItemAddedMessage
+  | ResponseContentPartAddedMessage
+  | ResponseTextDeltaMessage
+  | ResponseTextDoneMessage
+  | ResponseOutputItemDoneMessage
+  | ResponseContentPartDoneMessage
+  | ResponseDoneMessage;

--- a/frontend/src/utils/ExhaustiveError.ts
+++ b/frontend/src/utils/ExhaustiveError.ts
@@ -1,0 +1,5 @@
+export class ExhaustiveError extends Error {
+  constructor(value: never, message = `Unsupported type: ${value}`) {
+    super(message);
+  }
+}


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/realtime-api-web-console/issues/46

# この PR で対応する範囲 / この PR で対応しない範囲

`ReceivedDataChannelMessage` を型安全にします。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

`ReceivedDataChannelMessage` の型定義を追加しました。

本当は型ガードの実装をするのが丁寧ですが `ExhaustiveError` を出すようにしたので最悪検知出来るという事で as を使う形で妥協しています。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし